### PR TITLE
feat: Add Trigger Build and Sync DB buttons to editor

### DIFF
--- a/netlify/functions/api/editor_template.html
+++ b/netlify/functions/api/editor_template.html
@@ -229,6 +229,9 @@
             </div>
 
             <button type="submit" class="w-full p-3 bg-blue-500 text-white rounded-md shadow-lg focus:outline-none focus:ring-2 hover:bg-blue-600">Submit</button>
+            <button id="triggerBuildBtn" class="w-full mt-2 p-3 bg-green-500 hover:bg-green-600 text-white rounded-md shadow-lg focus:outline-none focus:ring-2">Trigger Build</button>
+            <button id="syncDbBtn" class="w-full mt-2 p-3 bg-yellow-500 hover:bg-yellow-600 text-white rounded-md shadow-lg focus:outline-none focus:ring-2">Sync DB</button>
+            <div id="adminActionsMessages" class="mt-4 p-4 border rounded-md"></div>
         </form>
     </div>
 
@@ -265,6 +268,84 @@
             } catch (error) {
                 console.error("Error:", error);
                 alert("Failed to submit post. Check console for details.");
+            }
+        });
+
+        async function triggerBuild(event) {
+            event.preventDefault();
+            const username = document.getElementById("username").value;
+            const password = document.getElementById("password").value;
+            const messagesDiv = document.getElementById("adminActionsMessages");
+            messagesDiv.className = 'mt-4 p-4 border rounded-md text-gray-700 border-gray-300'; // Reset to default/info
+            messagesDiv.textContent = "Triggering build...";
+
+            try {
+                const response = await fetch("/api/trigger-build", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ username, password })
+                });
+
+                const result = await response.json();
+
+                if (!response.ok) {
+                    const errorResult = result.message || `HTTP error! Status: ${response.status}`;
+                    throw new Error(errorResult);
+                }
+                messagesDiv.className = 'mt-4 p-4 border rounded-md text-green-700 border-green-500 bg-green-50';
+                messagesDiv.textContent = "Build triggered successfully: " + (result.message || "Done.");
+                console.log("Build trigger success:", result);
+            } catch (error) {
+                messagesDiv.className = 'mt-4 p-4 border rounded-md text-red-700 border-red-500 bg-red-50';
+                messagesDiv.textContent = "Failed to trigger build: " + error.message;
+                console.error("Build trigger error:", error);
+            }
+        }
+
+        async function syncDB(event) {
+            event.preventDefault();
+            const username = document.getElementById("username").value;
+            const password = document.getElementById("password").value;
+            const messagesDiv = document.getElementById("adminActionsMessages");
+            messagesDiv.className = 'mt-4 p-4 border rounded-md text-gray-700 border-gray-300'; // Reset to default/info
+            messagesDiv.textContent = "Syncing DB...";
+
+            try {
+                const response = await fetch("/api/sync-db", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ username, password })
+                });
+
+                const result = await response.json();
+
+                if (!response.ok) {
+                    const errorResult = result.message || `HTTP error! Status: ${response.status}`;
+                    throw new Error(errorResult);
+                }
+                messagesDiv.className = 'mt-4 p-4 border rounded-md text-green-700 border-green-500 bg-green-50';
+                messagesDiv.textContent = "DB synced successfully: " + (result.message || "Done.");
+                console.log("DB sync success:", result);
+            } catch (error) {
+                messagesDiv.className = 'mt-4 p-4 border rounded-md text-red-700 border-red-500 bg-red-50';
+                messagesDiv.textContent = "Failed to sync DB: " + error.message;
+                console.error("DB sync error:", error);
+            }
+        }
+        
+        document.addEventListener('DOMContentLoaded', () => {
+            const triggerBuildButton = document.getElementById("triggerBuildBtn");
+            if(triggerBuildButton) {
+                triggerBuildButton.addEventListener("click", triggerBuild);
+            }
+
+            const syncDbButton = document.getElementById("syncDbBtn");
+            if(syncDbButton) {
+                syncDbButton.addEventListener("click", syncDB);
             }
         });
     </script>


### PR DESCRIPTION
Adds "Trigger Build" and "Sync DB" buttons to the post editor page, enabling administrators to initiate site rebuilds and content synchronization directly from the editor.

Key changes:

-   **Editor Template (`netlify/functions/api/editor_template.html`):**
    -   Added "Trigger Build" and "Sync DB" buttons with appropriate styling.
    -   Included a message area to display feedback (info, success, error) from these actions.
    -   Implemented client-side JavaScript to handle button clicks, retrieve credentials, call backend APIs, and update the message area with styled success/error feedback.

-   **API Backend (`netlify/functions/api/main.go`):**
    -   Added new API endpoints: `/api/trigger-build` and `/api/sync-db`.
    -   These endpoints reuse the existing user authentication logic.
    -   Upon successful authentication, they make an HTTP POST request to the `/.netlify/functions/trigger-build` Netlify function, passing the required `X-Trigger-Secret`.
    -   Currently, "Sync DB" acts as an alias for "Trigger Build".
    -   Enhanced error handling and logging for these new routes.

-   **User Experience:**
    -   Feedback messages in the editor are now styled (color-coded) for better visual distinction of info, success, and error states.

The functionality relies on existing environment variables for database access, Netlify trigger secrets, and application base URL. Testing should verify these integrations and the end-to-end workflow of the new admin actions.